### PR TITLE
Add TypeScript JSON-DOC loader

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -1,0 +1,13 @@
+# jsondoc-ts
+
+TypeScript utilities for working with JSON-DOC documents. The models are a
+simplified port of the Python version. The main entry point is
+`loadJsondoc` which parses a JSON object (page or block) into typed
+structures.
+
+To run the tests:
+
+```bash
+cd ts
+npm run test
+```

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "jsondoc-ts",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node dist/tests/test_serialization.js"
+  },
+  "devDependencies": {}
+}

--- a/ts/src/loader.ts
+++ b/ts/src/loader.ts
@@ -1,0 +1,42 @@
+import { Block, BlockBase, BlockType, Page } from './models';
+
+function isObject(value: any): value is Record<string, any> {
+  return value !== null && typeof value === 'object';
+}
+
+export function loadBlock(data: any): Block {
+  if (!isObject(data) || data.object !== 'block') {
+    throw new Error('Invalid block object');
+  }
+  const base: BlockBase = data as BlockBase;
+  if (base.children) {
+    base.children = base.children.map(loadBlock);
+  }
+  return base as Block;
+}
+
+export function loadPage(data: any): Page {
+  if (!isObject(data) || data.object !== 'page') {
+    throw new Error('Invalid page object');
+  }
+  const page = data as Page;
+  page.children = (page.children || []).map(loadBlock);
+  return page;
+}
+
+export function loadJsondoc(data: any): Page | Block | Block[] {
+  if (Array.isArray(data)) {
+    return data.map(loadBlock);
+  }
+  if (data.object === 'page') {
+    return loadPage(data);
+  }
+  if (data.object === 'block') {
+    return loadBlock(data);
+  }
+  throw new Error("Invalid JSON-DOC object");
+}
+
+export function jsondocDumpJson(obj: Page | Block | Block[]): string {
+  return JSON.stringify(obj, null, 2);
+}

--- a/ts/src/models.ts
+++ b/ts/src/models.ts
@@ -1,0 +1,171 @@
+export type Color =
+  | 'blue'
+  | 'blue_background'
+  | 'brown'
+  | 'brown_background'
+  | 'default'
+  | 'gray'
+  | 'gray_background'
+  | 'green'
+  | 'green_background'
+  | 'orange'
+  | 'orange_background'
+  | 'yellow'
+  | 'yellow_background'
+  | 'pink'
+  | 'pink_background'
+  | 'purple'
+  | 'purple_background'
+  | 'red'
+  | 'red_background';
+
+export interface Annotations {
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;
+  underline?: boolean;
+  code?: boolean;
+  color?: string;
+}
+
+export interface Parent {
+  type: string;
+  block_id?: string;
+  page_id?: string;
+}
+
+export interface CreatedBy {
+  object: 'user';
+  id: string;
+}
+
+export interface LastEditedBy {
+  object: 'user';
+  id: string;
+}
+
+export interface RichTextText {
+  type: 'text';
+  text: {
+    content: string;
+    link?: { url: string } | null;
+  };
+  annotations: Annotations;
+  plain_text: string;
+  href?: string | null;
+}
+
+export type RichText = RichTextText; // Extend with other rich text types as needed
+
+export interface Paragraph {
+  rich_text: RichText[];
+  color?: Color;
+}
+
+export interface ToDo {
+  rich_text: RichText[];
+  checked?: boolean;
+  color?: Color;
+}
+
+export interface ColumnList {}
+export interface Column {}
+export interface Toggle {
+  rich_text: RichText[];
+  color?: Color;
+}
+
+export type BlockType =
+  | 'paragraph'
+  | 'to_do'
+  | 'bulleted_list_item'
+  | 'numbered_list_item'
+  | 'code'
+  | 'column'
+  | 'column_list'
+  | 'divider'
+  | 'equation'
+  | 'heading_1'
+  | 'heading_2'
+  | 'heading_3'
+  | 'image'
+  | 'quote'
+  | 'table'
+  | 'table_row'
+  | 'toggle';
+
+export interface BlockBase {
+  object: 'block';
+  id: string;
+  parent?: Parent;
+  type: BlockType;
+  created_time: string;
+  created_by?: CreatedBy;
+  last_edited_time?: string;
+  last_edited_by?: LastEditedBy;
+  archived?: boolean;
+  in_trash?: boolean;
+  has_children?: boolean;
+  children?: Block[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ParagraphBlock extends BlockBase {
+  type: 'paragraph';
+  paragraph: Paragraph;
+}
+
+export interface ToDoBlock extends BlockBase {
+  type: 'to_do';
+  to_do: ToDo;
+}
+
+export interface ColumnBlock extends BlockBase {
+  type: 'column';
+  column: Column;
+}
+
+export interface ColumnListBlock extends BlockBase {
+  type: 'column_list';
+  column_list: ColumnList;
+}
+
+export interface ToggleBlock extends BlockBase {
+  type: 'toggle';
+  toggle: Toggle;
+}
+
+export type Block =
+  | ParagraphBlock
+  | ToDoBlock
+  | ColumnBlock
+  | ColumnListBlock
+  | ToggleBlock;
+
+export interface TitleProperty {
+  id?: string;
+  type: 'title';
+  title?: RichTextText[];
+}
+
+export interface Properties {
+  title?: TitleProperty;
+}
+
+export interface Page {
+  object: 'page';
+  id: string;
+  parent?: Parent;
+  created_time: string;
+  created_by?: CreatedBy;
+  last_edited_time?: string;
+  last_edited_by?: LastEditedBy;
+  icon?: {
+    type: 'emoji';
+    emoji: string;
+  };
+  archived?: boolean;
+  in_trash?: boolean;
+  properties: Properties;
+  children: Block[];
+}

--- a/ts/tests/test_serialization.ts
+++ b/ts/tests/test_serialization.ts
@@ -1,0 +1,50 @@
+declare var __dirname: string;
+declare var require: any;
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { loadPage, jsondocDumpJson } = require('../src/loader');
+
+function loadJsonFile(filePath: string): any {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const cleaned = raw
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+  return JSON.parse(cleaned);
+}
+
+function removeNulls(obj: any): any {
+  if (Array.isArray(obj)) return obj.map(removeNulls);
+  if (obj && typeof obj === 'object') {
+    const newObj: any = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (v !== null) newObj[k] = removeNulls(v);
+    }
+    return newObj;
+  }
+  return obj;
+}
+
+function sortKeys(value: any): any {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === 'object') {
+    const sorted: any = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = sortKeys((value as any)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+const pagePath = path.join(__dirname, '../../../schema/page/ex1_success.json');
+const content = loadJsonFile(pagePath);
+const page = loadPage(JSON.parse(JSON.stringify(content)));
+const serialized = JSON.parse(jsondocDumpJson(page));
+
+const canonicalOriginal = sortKeys(removeNulls(content));
+const canonicalSerialized = sortKeys(removeNulls(serialized));
+
+assert.deepStrictEqual(canonicalSerialized, canonicalOriginal);
+console.log('test_serialization passed');

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "noImplicitAny": false
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- add an initial TypeScript port under `ts/`
- define interfaces for common JSON-DOC structures
- implement basic JSON-DOC parsing functions
- provide a simple test that checks round-trip serialization

## Testing
- `npm run test`