### PR TITLE
Add TypeScript schema generator

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -1,0 +1,14 @@
+# jsondoc-ts
+
+TypeScript utilities for working with JSON-DOC documents. Interfaces are
+generated from the JSON Schema definitions in `../schema` using the
+`json-schema-to-typescript` package. The main entry point is `loadJsondoc`
+which parses a JSON object (page or block) into typed structures.
+
+To (re)generate the models and run the tests:
+
+```bash
+cd ts
+npm run build
+npm run test
+```

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "jsondoc-ts",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "scripts": {
+    "generate": "node scripts/generate.js",
+    "build": "npm run generate && tsc",
+    "test": "npm run build && node dist/tests/test_serialization.js"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.19",
+    "json-schema-to-typescript": "^10.1.5",
+    "typescript": "^5.3.3"
+  }
+}

--- a/ts/scripts/generate.js
+++ b/ts/scripts/generate.js
@@ -1,0 +1,41 @@
+const fs = require('fs/promises');
+const path = require('path');
+const { compileFromFile } = require('json-schema-to-typescript');
+
+async function processDir(inputDir, outputDir, rootDir) {
+  const entries = await fs.readdir(inputDir, { withFileTypes: true });
+  await fs.mkdir(outputDir, { recursive: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(inputDir, entry.name);
+    const destPath = path.join(
+      outputDir,
+      entry.name.replace(/_schema\.json$/, '.ts')
+    );
+
+    if (entry.isDirectory()) {
+      await processDir(srcPath, path.join(outputDir, entry.name), rootDir);
+    } else if (entry.isFile() && entry.name.endsWith('_schema.json')) {
+      const ts = await compileFromFile(srcPath, {
+        bannerComment: '',
+        cwd: rootDir,
+      });
+      await fs.mkdir(path.dirname(destPath), { recursive: true });
+      await fs.writeFile(destPath, ts);
+      console.log(`Generated ${path.relative('.', destPath)}`);
+    }
+  }
+}
+
+async function main() {
+  const base = path.resolve(__dirname, '..');
+  const schemaDir = path.resolve(base, '..', 'schema');
+  const outDir = path.resolve(base, 'src', 'generated');
+  const rootDir = path.resolve(base, '..');
+  await processDir(schemaDir, outDir, rootDir);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ts/src/generated/index.ts
+++ b/ts/src/generated/index.ts
@@ -1,0 +1,4 @@
+// Placeholder generated file. Run `npm run generate` to regenerate.
+export interface Page {}
+export interface BlockBase { object: string; }
+export type Block = BlockBase;

--- a/ts/src/loader.ts
+++ b/ts/src/loader.ts
@@ -1,0 +1,42 @@
+import { Block, BlockBase, Page } from './generated';
+
+function isObject(value: any): value is Record<string, any> {
+  return value !== null && typeof value === 'object';
+}
+
+export function loadBlock(data: any): Block {
+  if (!isObject(data) || data.object !== 'block') {
+    throw new Error('Invalid block object');
+  }
+  const base: BlockBase = data as BlockBase;
+  if (base.children) {
+    base.children = base.children.map(loadBlock);
+  }
+  return base as Block;
+}
+
+export function loadPage(data: any): Page {
+  if (!isObject(data) || data.object !== 'page') {
+    throw new Error('Invalid page object');
+  }
+  const page = data as Page;
+  page.children = (page.children || []).map(loadBlock);
+  return page;
+}
+
+export function loadJsondoc(data: any): Page | Block | Block[] {
+  if (Array.isArray(data)) {
+    return data.map(loadBlock);
+  }
+  if (data.object === 'page') {
+    return loadPage(data);
+  }
+  if (data.object === 'block') {
+    return loadBlock(data);
+  }
+  throw new Error("Invalid JSON-DOC object");
+}
+
+export function jsondocDumpJson(obj: Page | Block | Block[]): string {
+  return JSON.stringify(obj, null, 2);
+}

--- a/ts/tests/test_serialization.ts
+++ b/ts/tests/test_serialization.ts
@@ -1,0 +1,50 @@
+declare var __dirname: string;
+declare var require: any;
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { loadPage, jsondocDumpJson } = require('../src/loader');
+
+function loadJsonFile(filePath: string): any {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const cleaned = raw
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+  return JSON.parse(cleaned);
+}
+
+function removeNulls(obj: any): any {
+  if (Array.isArray(obj)) return obj.map(removeNulls);
+  if (obj && typeof obj === 'object') {
+    const newObj: any = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (v !== null) newObj[k] = removeNulls(v);
+    }
+    return newObj;
+  }
+  return obj;
+}
+
+function sortKeys(value: any): any {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === 'object') {
+    const sorted: any = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = sortKeys((value as any)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+const pagePath = path.join(__dirname, '../../../schema/page/ex1_success.json');
+const content = loadJsonFile(pagePath);
+const page = loadPage(JSON.parse(JSON.stringify(content)));
+const serialized = JSON.parse(jsondocDumpJson(page));
+
+const canonicalOriginal = sortKeys(removeNulls(content));
+const canonicalSerialized = sortKeys(removeNulls(serialized));
+
+assert.deepStrictEqual(canonicalSerialized, canonicalOriginal);
+console.log('test_serialization passed');

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "noImplicitAny": false
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a script to generate TypeScript interfaces from the JSON Schemas
- wire up npm scripts and update docs
- remove the hand-written models
- stub generated models until generation can run

## Testing
- `npm run test` *(fails: Cannot find module 'json-schema-to-typescript')*
- `pytest` *(fails: command not found)*